### PR TITLE
Improvements to the code

### DIFF
--- a/qtest/.merlin
+++ b/qtest/.merlin
@@ -1,0 +1,5 @@
+S .
+B _build
+PKG oUnit
+PKG bytes
+FLG -w +a -w -4 -w -44

--- a/qtest/_oasis
+++ b/qtest/_oasis
@@ -4,7 +4,7 @@ Version:     2.0.0
 Synopsis:    qTest: inline unit tests extractor, from Batteries.
 Authors:     Vincent HUGOT
 License:     GPL-3.0
-Plugins:     META (0.2)
+Plugins:     META (0.2), DevFiles (0.3)
 
 Executable qtest
   Path:   .
@@ -18,4 +18,4 @@ Library "QTest2Lib"
   BuildTools:   ocamlbuild
   Modules:      Quickcheck, Runner
   BuildDepends: oUnit
-  
+

--- a/qtest/_oasis
+++ b/qtest/_oasis
@@ -10,7 +10,7 @@ Executable qtest
   Path:   .
   BuildTools:  ocamlbuild
   MainIs: qtest.ml
-  BuildDepends: str
+  BuildDepends: bytes
   CompiledObject: best
 
 Library "QTest2Lib"

--- a/qtest/_tags
+++ b/qtest/_tags
@@ -1,0 +1,5 @@
+# OASIS_START
+# OASIS_STOP
+<**/*.ml>: warn_A, warn(-4), warn(-44), warn(-50)
+# unescaped end-of-line
+<qtest.ml*>: warn(-29)

--- a/qtest/core.ml
+++ b/qtest/core.ml
@@ -4,7 +4,7 @@
  *)
 
 (**** TOOLKIT ****)
-module M = Misclex;;
+module M = Misclex
 let fpf = Printf.fprintf let va  = Printf.sprintf
 let epf = Printf.eprintf let eps  = prerr_string
 let pl  = print_endline
@@ -27,21 +27,26 @@ let (@@) f x = f x
 let soi = string_of_int
 (** Convert a [char] to a [string] *)
 let soc  = String.make 1
-let is_blank_char = function ' '|'\t'|'\n'|'\r' -> true | _ -> false 
+let is_blank_char = function ' '|'\t'|'\n'|'\r' -> true | _ -> false
 let listiteri f l = let c = ref (-1) in let call x = incr c; f !c x in
   List.iter call l
 let lex_str lexer s = (* use an ocamllex lexer *)
   let buff = Lexing.from_string s in lexer buff
 let trim = lex_str M.trim
 and normalise = lex_str M.normalise
+let first_chars s n =
+  let len = min n (String.length s) in String.sub s 0 len
+let string_after s n =
+  let len = String.length s - n in
+  String.sub s n len
 let snippet s n =
-  if String.length s <= n then s else Str.first_chars s n ^ "..."
+  if String.length s <= n then s else first_chars s n ^ "..."
 let snip lex = (** Snippet of current lexer buffer context *)
   let curr = max 0 (lex.Lexing.lex_start_pos - 5) in
-  let vicinity = Str.string_after lex.Lexing.lex_buffer curr
+  let vicinity = string_after lex.Lexing.lex_buffer curr
   in snippet vicinity 70
 (*****************)
- 
+
 (** output channel *)
 let outc = ref stdout
 (** main output function *)
@@ -102,7 +107,7 @@ type kind =
 (** a test : several statements *)
 type 'a test = {
   header : 'a ; (* bindings or metabindings *)
-  kind : kind ; 
+  kind : kind ;
   line : int ;  (* header line number *)
   source : string ; (* original source file *)
   statements : statement list ; (* test code *)
@@ -142,7 +147,7 @@ exception Invalid_pragma of string
 let str_of_metabinding (bind:metabinding) =
   let targets,alias = bind in String.concat ", " targets ^
   if List.length targets > 1 || List.hd targets <> alias then " as " ^ alias else ""
-    
+
 let str_of_binding ((f,a):binding) = str_of_metabinding ([f],a)
 
 (** lexical closure generation, single binding *)
@@ -173,7 +178,7 @@ let headers_of_metaheader (mh:metaheader) =
   in match mh.mhb with
   | [] ->  [{hb = []; hpar = mh.mhpar}]
   | l -> ((List.map (fun b-> {hb = b; hpar = mh.mhpar}) (z l)) : header list)
-  
+
 (** break down metatests (tests w/ multiple targets) and enforce that each
   test is non-empty, ie. has at least one statement.
   Also, put the statements back in the order they appear in *)
@@ -207,19 +212,19 @@ let retain_test test = match !_run_only with
 (** execute a pragma; in particular, output the executable version of a test *)
 let process uid = function
   | Test test when retain_test test  ->
-    let test_handle = test_handle_of_uid uid 
+    let test_handle = test_handle_of_uid uid
     and targets = targets_of_header test.header in
     List.iter (fun t->
       outf_target "%30s %4d    %s\n" test.source test.line t
     ) targets;
     outf "let %s = %S >::: [\n" test_handle (get_test_name test);
     (* handle individual statements *)
-    let do_statement st = 
+    let do_statement st =
       let location = va "%s:%d" test.source st.ln in
       let extended_name = va "\"%s\"" (* pretty, detailed name for the test *)
-        (String.escaped location^":  "^String.escaped (prettify st.code)) 
+        (String.escaped location^":  "^String.escaped (prettify st.code))
       and lnumdir = va "\n#%d \"%s\"\n" st.ln test.source in
-      let bind = lnumdir ^ code_of_bindings test.header.hb 
+      let bind = lnumdir ^ code_of_bindings test.header.hb
       in match test.kind with
       | Simple -> outf
         "\"%s\" >:: (%s fun () -> OUnit.assert_bool %s (%s%s%s));\n"
@@ -294,7 +299,7 @@ let rec shuffle = function
     then List.map shuffle il else List.map shuffle (durstenfeld il))
   | Env _ -> assert false
 
-       
+
 let exec suite =
 (*   assert (!suite = output (input !suite)); *)
   suite := output @@ shuffle (input !suite)

--- a/qtest/doc/parts/hparams.tex
+++ b/qtest/doc/parts/hparams.tex
@@ -1,1 +1,7 @@
  coming soon...
+
+Use \verb!(*$inject foo *)! to inject the piece of code \verb!foo! at the beginning
+of this module's tests. This is useful, for instance, to define
+frequently used random generators, or printers, or
+to instantiate a functor before testing it.
+

--- a/qtest/misclex.mll
+++ b/qtest/misclex.mll
@@ -3,7 +3,7 @@
  * qTest: quick unit tests: extract oUnit tests from OCaml components
  * under GNU GPL v3: see qtest.mll
  *)
-module B = Buffer;;
+module B = Buffer
 let b = B.create 80
 } (***************************************************************)
 

--- a/qtest/qparse.mly
+++ b/qtest/qparse.mly
@@ -1,5 +1,5 @@
 %{
-open Core;;
+open Core
 %}
 
 %token <string> ID PARAM UID

--- a/qtest/qtest.mll
+++ b/qtest/qtest.mll
@@ -22,10 +22,10 @@
  *
  *)
 
-open Core;;
-open Qparse;;
+open Core
+open Qparse
 
-module B = Buffer;;
+module B = Buffer
 (** the do-it-all buffer; always clear *after* use *)
 let buffy = B.create 80
 
@@ -244,7 +244,7 @@ Open or create a file for output; the resulting file will be an OCaml source fil
 "-p",               Arg.String add_preamble, "";
 "--preamble",       Arg.String add_preamble,
 "<string>   (default: empty)\n\
-Add code to the tests preamble; typically this will be an instruction of the form 'open Module;;'\n\
+Add code to the tests preamble; typically this will be an instruction of the form 'open Module'\n\
 ";
 
 "--preamble-file",  Arg.String add_preamble_file,

--- a/qtest/qtest.mll
+++ b/qtest/qtest.mll
@@ -237,35 +237,35 @@ let set_output path =
 let options = [
 "-o",               Arg.String set_output, "";
 "--output",         Arg.String set_output,
-"<path>     (default: standard output)
-Open or create a file for output; the resulting file will be an OCaml source file containing all the tests
+"<path>     (default: standard output)\n\
+Open or create a file for output; the resulting file will be an OCaml source file containing all the tests\n\
 ";
 
 "-p",               Arg.String add_preamble, "";
 "--preamble",       Arg.String add_preamble,
-"<string>   (default: empty)
-Add code to the tests preamble; typically this will be an instruction of the form 'open Module;;'
+"<string>   (default: empty)\n\
+Add code to the tests preamble; typically this will be an instruction of the form 'open Module;;'\n\
 ";
 
 "--preamble-file",  Arg.String add_preamble_file,
-"<path>
-Add the contents of the given file to the tests preamble
+"<path>\n\
+Add the contents of the given file to the tests preamble\n\
 ";
 
 "--run-only",       Arg.String (fun s->Core._run_only := Some s),
-"<function name>
-Only generate tests pertaining to this function, as indicated by the test header
+"<function name>\n\
+Only generate tests pertaining to this function, as indicated by the test header\n\
 ";
 
 "--shuffle",        Arg.Unit (fun ()->toggle _shuffle; if !_shuffle then epf "!!! SHUFFLE is ON !!!\n"),
-"           (default: turned off)
+"           (default: turned off)\n\
 Toggle test execution order randomisation; submodules using injection are not shuffled";
 ]
 
 let usage_msg =
 (* OPTIONS: is here to mimick the pre-Arg behavior *)
-"USAGE: qtest [options] extract <file.mli?>...
-
+"USAGE: qtest [options] extract <file.mli?>...\n\
+\n\
 OPTIONS:"
 
 let () =

--- a/qtest/qtest.mll
+++ b/qtest/qtest.mll
@@ -226,7 +226,7 @@ let generate paths =
 
 let add_preamble code =
   Buffer.add_string global_preamble code;
-  Buffer.add_string global_preamble "\n"  
+  Buffer.add_string global_preamble "\n"
 let add_preamble_file path =
   let input = open_in path in
   Buffer.add_channel global_preamble input (in_channel_length input);
@@ -234,31 +234,31 @@ let add_preamble_file path =
 let set_output path =
   epf "Target file: `%s'. " path; outc := open_out path
 
-let options = [
+let options = Arg.align [
 "-o",               Arg.String set_output, "";
 "--output",         Arg.String set_output,
-"<path>     (default: standard output)\n\
-Open or create a file for output; the resulting file will be an OCaml source file containing all the tests\n\
+" <path>     (default: standard output) \
+Open or create a file for output; the resulting file will be an OCaml source file containing all the tests\
 ";
 
 "-p",               Arg.String add_preamble, "";
 "--preamble",       Arg.String add_preamble,
-"<string>   (default: empty)\n\
-Add code to the tests preamble; typically this will be an instruction of the form 'open Module'\n\
+" <string>   (default: empty) \
+Add code to the tests preamble; typically this will be an instruction of the form 'open Module'\
 ";
 
 "--preamble-file",  Arg.String add_preamble_file,
-"<path>\n\
+" <path> \
 Add the contents of the given file to the tests preamble\n\
 ";
 
 "--run-only",       Arg.String (fun s->Core._run_only := Some s),
-"<function name>\n\
-Only generate tests pertaining to this function, as indicated by the test header\n\
+" <function name> \
+Only generate tests pertaining to this function, as indicated by the test header\
 ";
 
 "--shuffle",        Arg.Unit (fun ()->toggle _shuffle; if !_shuffle then epf "!!! SHUFFLE is ON !!!\n"),
-"           (default: turned off)\n\
+" (default: turned off) \
 Toggle test execution order randomisation; submodules using injection are not shuffled";
 ]
 
@@ -276,7 +276,7 @@ let () =
   match List.rev !rev_anon_args with
     | [] -> pl "qtest: use --help for usage notes."
     | "extract" :: paths -> generate paths
-    | arg :: _ -> 
+    | arg :: _ ->
       Arg.usage options usage_msg; prerr_newline();
       failwith @@ "bad argument: " ^ arg
 }

--- a/qtest/runner.ml
+++ b/qtest/runner.ml
@@ -1,4 +1,4 @@
-open OUnit;;
+open OUnit
 
 let ps,pl = print_string,print_endline
 let va = Printf.sprintf


### PR DESCRIPTION
I've started refactoring the code, eliminating warnings, getting closer to `-safe-string` compatibility, and started adding doc (I missed `(*$inject` and discovered it by reading the lexer...). Could the doc, maybe, be written in something like markdown or asciidoc rather than LaTeX?

I'm planning to change the API of the `quickcheck` library to make it more powerful and closer to the original `QuickCheck` (shrinking, etc.). I read that a `qtest 3` was not impossible in principle, so I want to change `'a gen_print` into an object with a generator and several optional methods for printing, shrinking, etc.

Do those more ambitious changes have a change to be merged?