### PR TITLE
support lexer directives in input files

### DIFF
--- a/src/qtest.mll
+++ b/src/qtest.mll
@@ -58,6 +58,19 @@ let uident = uppercase identchar*
 
 (** extract tests from ml file *)
 rule lexml t = parse
+  | "#" [' ' '\t']*
+        (['0'-'9']+ as line) [' ' '\t']*
+        ("\"" ([^ '\010' '\013' '\"' ] * as file) "\"")? [' ' '\t']* '\n' {
+    (* lexer directives *)
+    let file = match file with
+      | Some file -> file
+      | None -> Lexing.(lexbuf.lex_curr_p.pos_fname) in
+    Lexing.(lexbuf.lex_curr_p <-
+              {lexbuf.lex_curr_p with
+               pos_fname = file;
+               pos_lnum = int_of_string line;
+              }) }
+
   (* test pragmas *)
   (****************)
 | "(*$QR" { (* quickcheck random test, in a raw form *)

--- a/tests/cppo.ml.cppo
+++ b/tests/cppo.ml.cppo
@@ -1,0 +1,2 @@
+let included x = x
+#include "cppo.test.ml"

--- a/tests/cppo.test.ml
+++ b/tests/cppo.test.ml
@@ -1,0 +1,3 @@
+(*$T included
+  included false
+*)

--- a/tests/directives.ml
+++ b/tests/directives.ml
@@ -1,0 +1,31 @@
+(* first in the original file *)
+let _id1 x = x;;
+(*$T _id1
+  _id1 true
+  _id1 (2 = 2)
+  _id1 (3 + 1 = 4)
+*)
+
+# 8 "another_file.ml"
+(* then in another file *)
+let _id2 x = x;;
+(*$T _id2
+  _id2 true
+*)
+
+# 3 "with_different_lines.ml"
+let _id3 x = x;;
+(*$T _id3
+  _id3 true
+  _id3 (5 + 1 = 6)
+*)
+# 20 "final_file.ml"
+(* in the middle of things *)
+let _id4 x = x;;
+(*$T _id4
+  _id4 true
+  _id4 (1 = 1)
+  _id4 true
+  _id4 true
+  _id4 true
+*)

--- a/tests/directives.ml.reference
+++ b/tests/directives.ml.reference
@@ -1,0 +1,79 @@
+let ___tests = ref []
+let ___add test = ___tests := test::!___tests
+open OUnit;;
+module Q = QCheck;;let ( ==> ) = Q.( ==> );;
+
+
+
+
+module Test__environment_0 = struct
+open Directives;;
+let _test_2 = "_id1" >::: [
+"directives.ml:4" >:: (
+#4 "directives.ml"
+let _id1 = _id1 in fun () -> OUnit.assert_bool "directives.ml:4:  _id1 true" (
+#4 "directives.ml"
+  _id1 true));
+"directives.ml:5" >:: (
+#5 "directives.ml"
+let _id1 = _id1 in fun () -> OUnit.assert_bool "directives.ml:5:  _id1 (2 = 2)" (
+#5 "directives.ml"
+  _id1 (2 = 2)));
+"directives.ml:6" >:: (
+#6 "directives.ml"
+let _id1 = _id1 in fun () -> OUnit.assert_bool "directives.ml:6:  _id1 (3 + 1 = 4)" (
+#6 "directives.ml"
+  _id1 (3 + 1 = 4)));
+];; let _ = ___add _test_2;;
+let _test_3 = "_id2" >::: [
+"another_file.ml:11" >:: (
+#11 "another_file.ml"
+let _id2 = _id2 in fun () -> OUnit.assert_bool "another_file.ml:11:  _id2 true" (
+#11 "another_file.ml"
+  _id2 true));
+];; let _ = ___add _test_3;;
+let _test_4 = "_id3" >::: [
+"with_different_lines.ml:5" >:: (
+#5 "with_different_lines.ml"
+let _id3 = _id3 in fun () -> OUnit.assert_bool "with_different_lines.ml:5:  _id3 true" (
+#5 "with_different_lines.ml"
+  _id3 true));
+"with_different_lines.ml:6" >:: (
+#6 "with_different_lines.ml"
+let _id3 = _id3 in fun () -> OUnit.assert_bool "with_different_lines.ml:6:  _id3 (5 + 1 = 6)" (
+#6 "with_different_lines.ml"
+  _id3 (5 + 1 = 6)));
+];; let _ = ___add _test_4;;
+let _test_5 = "_id4" >::: [
+"final_file.ml:23" >:: (
+#23 "final_file.ml"
+let _id4 = _id4 in fun () -> OUnit.assert_bool "final_file.ml:23:  _id4 true" (
+#23 "final_file.ml"
+  _id4 true));
+"final_file.ml:24" >:: (
+#24 "final_file.ml"
+let _id4 = _id4 in fun () -> OUnit.assert_bool "final_file.ml:24:  _id4 (1 = 1)" (
+#24 "final_file.ml"
+  _id4 (1 = 1)));
+"final_file.ml:25" >:: (
+#25 "final_file.ml"
+let _id4 = _id4 in fun () -> OUnit.assert_bool "final_file.ml:25:  _id4 true" (
+#25 "final_file.ml"
+  _id4 true));
+"final_file.ml:26" >:: (
+#26 "final_file.ml"
+let _id4 = _id4 in fun () -> OUnit.assert_bool "final_file.ml:26:  _id4 true" (
+#26 "final_file.ml"
+  _id4 true));
+"final_file.ml:27" >:: (
+#27 "final_file.ml"
+let _id4 = _id4 in fun () -> OUnit.assert_bool "final_file.ml:27:  _id4 true" (
+#27 "final_file.ml"
+  _id4 true));
+];; let _ = ___add _test_5;;
+end
+
+let _ = try
+    exit (QCheck_runner.run ("" >::: List.rev !___tests))
+    with Arg.Bad msg -> print_endline msg; exit 1
+    | Arg.Help msg -> print_endline msg; exit 0

--- a/tests/testcppo.sh
+++ b/tests/testcppo.sh
@@ -1,0 +1,11 @@
+set -e # stop on first error
+echo | cppo > /dev/null \
+  || (echo "cppo is required to run this test"; exit 1)
+cppo cppo.ml.cppo > cppo.ml
+qtest extract cppo.ml -o cppo_test.ml
+ocamlbuild -cflags -warn-error,+26 -use-ocamlfind -pkg oUnit,qcheck cppo_test.native
+./cppo_test.native 2>&1 | grep cppo.test.ml >/dev/null \
+  || { echo "test failed"; exit 1; } \
+  && { rm -f cppo.ml cppo_test.ml; echo "test passed"; }
+
+

--- a/tests/testdirectives.sh
+++ b/tests/testdirectives.sh
@@ -1,0 +1,5 @@
+set -e # stop on first error
+qtest extract directives.ml -o directives.ml.result
+diff -u directives.ml.{result,reference} > /dev/null \
+  || { echo "test failed"; exit 1; } \
+  && { rm -f directives.ml.result; echo "test passed"; }


### PR DESCRIPTION
In Batteries it would be helpful to have qtest recognize lexer directives in input files (it gives compilation errors in the right place for test that comes from preprocessed `.mlv` files).